### PR TITLE
Added check for listeners before calling foreach.

### DIFF
--- a/src/Spl/HashingMediator.php
+++ b/src/Spl/HashingMediator.php
@@ -73,6 +73,10 @@ class HashingMediator implements Mediator {
      * @return void
      */
     public function notify($event) {
+        if (empty($this->events[$event])) {
+            return;
+        }
+        
         $args = func_get_args();
         array_shift($args);
 


### PR DESCRIPTION
If an event is broadcast but has no listeners registered, you'll get a Warning: Invalid argument supplied for foreach()
