### PR TITLE
Add HashMap::keys() to allow access to object keys

### DIFF
--- a/src/Ardent/HashMap.php
+++ b/src/Ardent/HashMap.php
@@ -174,4 +174,16 @@ class HashMap implements Map {
         return count($this->storage);
     }
 
+    /**
+     * @return array
+     */
+    function keys() {
+        return array_map(
+            function ($pair) {
+                return $pair->first;
+            },
+            $this->storage
+        );
+    }
+
 }


### PR DESCRIPTION
This is more a bug report than an actual PR.

I tried to add `keys()` to `Map`, but I have no clue how to make it work for `SortedMap`. This hack works for my specific case right now, so maybe including something like it is actually feasible...

Please share your thoughts.
