### PR TITLE
Create Filterable and Mappable attributes

### DIFF
--- a/sources.mk
+++ b/sources.mk
@@ -1,5 +1,7 @@
 SOURCES = \
 	src/AbstractSet.php \
+	src/Attribute/Filterable.php
+	src/Attribute/Mappable.php
 	src/AvlTree.php \
 	src/BinarySearchTree.php \
 	src/BinaryTree.php \

--- a/src/Attribute/Filterable.php
+++ b/src/Attribute/Filterable.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Collections\Attribute;
+
+interface Filterable {
+
+    /**
+     * @param callable $filter
+     * @return \Traversable
+     */
+    function filter(callable $filter);
+
+}
+

--- a/src/Attribute/Mappable.php
+++ b/src/Attribute/Mappable.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Collections\Attribute;
+
+interface Mappable {
+    
+    /**
+     * @param callable $mapper
+     * @return \Traversable
+     */
+    function map(callable $mapper);
+
+}
+

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -2,7 +2,11 @@
 
 namespace Collections;
 
-interface Collection extends \Traversable {
+use Collections\Attribute\Filterable;
+use Collections\Attribute\Mappable;
+
+
+interface Collection extends \Traversable, Filterable, Mappable {
 
     /**
      * @return bool

--- a/src/function.php
+++ b/src/function.php
@@ -55,6 +55,8 @@ function autoload($className) {
     static $classMap = [
         'Collections\\AbstractSet' => 'AbstractSet.php',
         'Collections\\ArrayIterator' => 'Iterator/ArrayIterator.php',
+        'Collections\\Attribute\\Filterable' => 'Attribute/Filterable.php',
+        'Collections\\Attribute\\Mappable' => 'Attribute/Mappable.php',
         'Collections\\AvlTree' => 'AvlTree.php',
         'Collections\\BinarySearchTree' => 'BinarySearchTree.php',
         'Collections\\BinaryTree' => 'BinaryTree.php',


### PR DESCRIPTION
The idea here is is that some programmers may not want to implement all of the `Collection` interface. So by using interface segregation we can separate them out.

I'm not completely sold on this idea, though, which is why this is a pull request. I'm hoping to get some feedback.