### PR TITLE
Add map and filter algorithms

### DIFF
--- a/src/Iterator/FilteringIterator.php
+++ b/src/Iterator/FilteringIterator.php
@@ -17,7 +17,7 @@ class FilteringIterator extends IteratorCollectionAdapter {
     private $valid;
 
 
-    function __construct(\Iterator $iterator, callable $filter) {
+    function __construct($iterator, callable $filter) {
         parent::__construct($iterator);
         $this->filter = $filter;
     }

--- a/src/Iterator/IteratorCollectionAdapter.php
+++ b/src/Iterator/IteratorCollectionAdapter.php
@@ -12,8 +12,18 @@ class IteratorCollectionAdapter implements Enumerator, \OuterIterator {
     protected $inner;
 
 
-    function __construct(\Iterator $Iterator) {
-        $this->inner = $Iterator;
+    function __construct($iterable) {
+
+        if (is_array($iterable)) {
+            $iterator = new ArrayIterator($iterable);
+        } else if ($iterable instanceof \Iterator) {
+            $iterator = $iterable;
+        } else {
+            assert($iterable instanceof \Traversable);
+            $iterator = new \IteratorIterator($iterable);
+        }
+
+        $this->inner = $iterator;
     }
 
 

--- a/src/Iterator/MappingIterator.php
+++ b/src/Iterator/MappingIterator.php
@@ -10,7 +10,7 @@ class MappingIterator extends IteratorCollectionAdapter {
     private $mapper;
 
 
-    function __construct(\Iterator $iterator, callable $map) {
+    function __construct($iterator, callable $map) {
         parent::__construct($iterator);
         $this->mapper = $map;
     }

--- a/src/function.php
+++ b/src/function.php
@@ -3,6 +3,9 @@
 namespace Collections;
 
 
+use Collections\Attribute\Filterable;
+use Collections\Attribute\Mappable;
+
 function negate(callable $f) {
     return function () use ($f) {
         return !call_user_func_array($f, func_get_args());
@@ -162,5 +165,33 @@ function intGuard($i) {
         throw new TypeException;
     }
     return (int)$i;
+}
+
+
+/**
+ * @param callable $mapper
+ * @param $input
+ * @return \Traversable
+ */
+function map(callable $mapper, $input) {
+    if ($input instanceof Mappable) {
+        return $input->map($mapper);
+    }
+
+    return new MappingIterator($input, $mapper);
+}
+
+
+/**
+ * @param callable $filter
+ * @param $input
+ * @return \Traversable
+ */
+function filter(callable $filter, $input) {
+    if ($input instanceof Filterable) {
+        return $input->filter($filter);
+    }
+
+    return new FilteringIterator($input, $filter);
 }
 

--- a/test/Collections/Algorithms/FilterTest.php
+++ b/test/Collections/Algorithms/FilterTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Collections;
+
+
+class FilterTest extends \PHPUnit_Framework_TestCase {
+
+    function odd($value, $key = null) {
+        return $value % 2 > 0;
+    }
+
+    function test_filterable() {
+        $set = new HashSet();
+        $set->add(1);
+        $set->add(2);
+        $set->add(3);
+
+        $output = filter([$this, 'odd'], $set);
+        $expect = [1, 3];
+        $actual = iterator_to_array($output, false);
+        $this->assertEquals($expect, $actual);
+    }
+
+
+    function test_iterator() {
+        $in = new \ArrayIterator([1, 2, 3]);
+
+        $output = filter([$this, 'odd'], $in);
+        $expect = [1, 3];
+        $actual = iterator_to_array($output, false);
+        $this->assertEquals($expect, $actual);
+    }
+    
+
+}

--- a/test/Collections/Algorithms/MapTest.php
+++ b/test/Collections/Algorithms/MapTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Collections;
+
+
+class MapTest extends \PHPUnit_Framework_TestCase {
+
+    /**
+     * Helper because strlen will fatal if provided 2 parameters
+     */
+    function strlen($value, $key = null) {
+        return \strlen($value);
+    }
+
+    function test_mappable() {
+        $set = new HashSet();
+        $set->add('hello');
+
+        $output = map([$this, 'strlen'], $set);
+        $expect = [$this->strlen('hello')];
+        $actual = iterator_to_array($output);
+        $this->assertEquals($expect, $actual);
+    }
+
+
+    function test_iterator() {
+        $in = new \ArrayIterator(['hello']);
+
+        $out = map([$this, 'strlen'], $in);
+        $expect = [$this->strlen('hello')];
+        $actual = iterator_to_array($out);
+        $this->assertEquals($expect, $actual);
+    }
+
+
+}

--- a/test/Collections/IteratorCollectionAdapterTest.php
+++ b/test/Collections/IteratorCollectionAdapterTest.php
@@ -112,7 +112,7 @@ class IteratorCollectionAdapterTest extends \PHPUnit_Framework_TestCase {
 
     function testKeysMap() {
         $array = ['one' => 1, 'two' => 2, 'three' => 3];
-        $iterator = new IteratorCollectionAdapter(new ArrayIterator($array));
+        $iterator = new IteratorCollectionAdapter($array);
 
         $this->assertEquals(['one', 'two', 'three'], $iterator->keys()->toArray());
     }
@@ -120,7 +120,7 @@ class IteratorCollectionAdapterTest extends \PHPUnit_Framework_TestCase {
 
     function testValuesOnValuesReturnsSame() {
         $array = ['one' => 1, 'two' => 2, 'three' => 3];
-        $iterator = new ValueIterator(new ArrayIterator($array));
+        $iterator = new ValueIterator(new \ArrayObject($array));
 
         $this->assertSame($iterator, $iterator->values());
 


### PR DESCRIPTION
PR #41 added `Mappable` and `Filterable` interfaces – this uses those to specialize functions  `map` and `filter`. This is experimental as well and would like some feedback if possible.